### PR TITLE
feat: pre-LLM input classifier + status hint streaming fixes

### DIFF
--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,0 +1,66 @@
+# Task 2 Report — Client: force repaint between status events
+
+## Status: DONE
+
+## Changes made
+
+### File: `/var/www/html/public/local/craftpilot/amd/src/chat_interface.js`
+
+**Step 1 — Remove inline style from `.cp-status-hint` span (line 1016)**
+
+Removed `style="margin-left:10px;font-style:italic;font-size:12px;color:#555;display:inline-block"` from the span in `showTyping()`. The `.cp-status-hint` CSS rule already provides these properties.
+
+Before:
+```html
+'<span class="cp-status-hint" aria-live="polite" style="margin-left:10px;font-style:italic;font-size:12px;color:#555;display:inline-block"></span>'
+```
+After:
+```html
+'<span class="cp-status-hint" aria-live="polite"></span>'
+```
+
+**Step 2 — Rewrite `read` function in `streamFromBackend()` (lines 1134–1258)**
+
+- Changed `const read = () => reader.read().then(({ done, value }) => {` to `const read = async () => { const { done, value } = await reader.read();`
+- Changed `lines.forEach((line) => { ... });` to `for (const line of lines) { ... }` (enables `await` inside the loop)
+- In the `status` event handler: removed the 8-line `cp-dbg-overlay` diagnostic block; added `await new Promise(resolve => requestAnimationFrame(resolve))` after `hintEl.textContent = ev.data`
+- Changed closing `});` of the `.then()` chain to `};` and kept `return read();` at end of function body and after the definition
+- All other event handlers (`conversation_title`, `video_metadata`, `bvh_metadata`, `token`, `message`, `documents`, `error`) are character-for-character identical to the original
+
+## Build output
+
+```
+Running "babel:dist" (babel) task
+Browserslist: browsers data (caniuse-lite) is 10 months old. Please run:
+  npx update-browserslist-db@latest
+  Why you should do it regularly: https://github.com/browserslist/update-db#readme
+
+Done.
+```
+
+Build completed without errors. The browserslist warning is pre-existing and does not affect functionality. No `--force` was needed (the `.map` file warning did not appear this run).
+
+## Cache purge
+
+Ran:
+```bash
+find /var/www/moodledata/localcache -name "*.js" -delete 2>/dev/null || true
+find /var/www/moodledata/localcache -name "*.php" -delete 2>/dev/null || true
+```
+Completed successfully.
+
+**Note:** A full Moodle PHP cache purge is still recommended. Ask the user to run:
+```
+! sudo -u apache php /var/www/html/public/admin/cli/purge_caches.php
+```
+Or use Moodle admin UI: Site administration → Development → Purge all caches.
+
+## Self-review
+
+- Inline style removed — confirmed the span no longer carries `style=` attribute
+- `read` is now `async`; the outer `.then()` chain that calls `return read()` is unaffected (async functions return Promises)
+- `forEach` replaced with `for...of` — `await` inside the loop will now actually suspend execution
+- `requestAnimationFrame` yield is placed only in the `status` handler, after `hintEl.textContent = ev.data`, exactly as specified
+- The diagnostic `cp-dbg-overlay` block (8 lines, lines ~1177–1185 in the original) has been removed
+- All other event handlers are unchanged
+- Build passed; Moodle localcache purged

--- a/docs/superpowers/plans/2026-06-22-input-classifier.txt
+++ b/docs/superpowers/plans/2026-06-22-input-classifier.txt
@@ -1,0 +1,329 @@
+# Input Classifier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a pre-LLM topic classifier that short-circuits `stream_response()` with a soft refusal before any retrieval runs, when the user's question is off-topic.
+
+**Architecture:** A new async method `_classify_in_domain(message)` on `MoodleAIAssistantPipeline` calls the existing Infomaniak LLM with `max_tokens=5, temperature=0` and a French YES/NO prompt. It is called at the very top of `stream_response()` before title generation; off-topic questions receive a soft refusal token stream and the generator returns immediately.
+
+**Tech Stack:** Python asyncio, LangChain `ChatOpenAI` (via `self.rag_service.llm.bind()`), `unittest.mock`, pytest.
+
+## Global Constraints
+
+- No new dependencies — reuse `self.rag_service.llm` exactly as `_generate_conversation_title` does.
+- No new service classes — method lives directly on `MoodleAIAssistantPipeline` in `pipeline.py`.
+- Fail-open on any exception — return `True` (in-domain) so legitimate questions are never blocked by infrastructure errors.
+- Refusal text is generic (not domain-aware): `"Je n'ai pas trouvé d'information pertinente dans le corpus pour répondre à cette question. Veuillez poser une question sur les arts et métiers ou consulter votre formateur."`
+- Imports inside `stream_response` stay inside that method (existing pattern).
+
+---
+
+### Task 1: `_classify_in_domain` method + tests
+
+**Files:**
+- Modify: `pipeline.py` (add method after `_generate_conversation_title`, around line 309)
+- Test: `tests/test_pipeline_integration.py` (append to existing file)
+
+**Interfaces:**
+- Produces: `async def _classify_in_domain(self, message: str) -> bool` — `True` = in-domain, `False` = off-topic.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_pipeline_integration.py`:
+
+```python
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from pipeline import MoodleAIAssistantPipeline
+
+
+def _make_pipeline_with_mock_llm(response_content: str):
+    """Return a MoodleAIAssistantPipeline whose LLM is fully mocked."""
+    with patch.object(MoodleAIAssistantPipeline, "__init__", lambda self, *a, **kw: None):
+        pipeline = MoodleAIAssistantPipeline.__new__(MoodleAIAssistantPipeline)
+
+    mock_response = MagicMock()
+    mock_response.content = response_content
+
+    mock_bound_llm = MagicMock()
+    mock_bound_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+    mock_llm = MagicMock()
+    mock_llm.bind.return_value = mock_bound_llm
+
+    mock_rag_service = MagicMock()
+    mock_rag_service.llm = mock_llm
+
+    pipeline.rag_service = mock_rag_service
+    return pipeline
+
+
+@pytest.mark.asyncio
+async def test_classify_in_domain_returns_true_for_oui():
+    pipeline = _make_pipeline_with_mock_llm("OUI")
+    assert await pipeline._classify_in_domain("Comment souffler le verre ?") is True
+
+
+@pytest.mark.asyncio
+async def test_classify_in_domain_returns_true_for_yes():
+    pipeline = _make_pipeline_with_mock_llm("YES")
+    assert await pipeline._classify_in_domain("How do I shape molten glass?") is True
+
+
+@pytest.mark.asyncio
+async def test_classify_in_domain_returns_false_for_non():
+    pipeline = _make_pipeline_with_mock_llm("NON")
+    assert await pipeline._classify_in_domain("Qui est le président des États-Unis ?") is False
+
+
+@pytest.mark.asyncio
+async def test_classify_in_domain_returns_false_for_no():
+    pipeline = _make_pipeline_with_mock_llm("NO")
+    assert await pipeline._classify_in_domain("What is the capital of France?") is False
+
+
+@pytest.mark.asyncio
+async def test_classify_in_domain_fails_open_on_exception():
+    """Any LLM error must return True (fail-open) so real questions are never blocked."""
+    with patch.object(MoodleAIAssistantPipeline, "__init__", lambda self, *a, **kw: None):
+        pipeline = MoodleAIAssistantPipeline.__new__(MoodleAIAssistantPipeline)
+
+    mock_bound_llm = MagicMock()
+    mock_bound_llm.ainvoke = AsyncMock(side_effect=Exception("network error"))
+
+    mock_llm = MagicMock()
+    mock_llm.bind.return_value = mock_bound_llm
+
+    mock_rag_service = MagicMock()
+    mock_rag_service.llm = mock_llm
+    pipeline.rag_service = mock_rag_service
+
+    result = await pipeline._classify_in_domain("Qui est Napoleon ?")
+    assert result is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /opt/craftpilot_backend && python -m pytest tests/test_pipeline_integration.py::test_classify_in_domain_returns_true_for_oui tests/test_pipeline_integration.py::test_classify_in_domain_returns_false_for_non tests/test_pipeline_integration.py::test_classify_in_domain_fails_open_on_exception -v
+```
+
+Expected: `AttributeError: type object 'MoodleAIAssistantPipeline' has no attribute '_classify_in_domain'`
+
+- [ ] **Step 3: Implement `_classify_in_domain`**
+
+In `pipeline.py`, add this method immediately after `_generate_conversation_title` (after line ~309, before the `@traceable` decorator on `stream_response`):
+
+```python
+async def _classify_in_domain(self, message: str) -> bool:
+    """Return True if message is in-domain (craft trades / apprenticeship).
+
+    Uses a minimal LLM call (max_tokens=5, temperature=0) to classify.
+    Fails open on any exception so legitimate questions are never blocked.
+    """
+    try:
+        from langchain_core.messages import SystemMessage, HumanMessage
+        classifier_llm = self.rag_service.llm.bind(max_tokens=5, temperature=0)
+        system = SystemMessage(content=(
+            "Tu es un classifieur de sujets. Réponds par un seul mot : "
+            "OUI si la question concerne les arts et métiers, l'apprentissage, "
+            "les techniques artisanales (soufflage de verre, ganterie, menuiserie, "
+            "sellerie, etc.). Réponds NON pour tout le reste (politique, actualité, "
+            "géographie, célébrités, etc.). Réponds uniquement OUI ou NON."
+        ))
+        human = HumanMessage(content=message)
+        response = await classifier_llm.ainvoke([system, human])
+        answer = response.content.strip().upper()
+        return answer.startswith("OUI") or answer.startswith("YES")
+    except Exception as e:
+        logger.warning(f"Input classifier failed (fail-open): {e}")
+        return True
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /opt/craftpilot_backend && python -m pytest tests/test_pipeline_integration.py::test_classify_in_domain_returns_true_for_oui tests/test_pipeline_integration.py::test_classify_in_domain_returns_true_for_yes tests/test_pipeline_integration.py::test_classify_in_domain_returns_false_for_non tests/test_pipeline_integration.py::test_classify_in_domain_returns_false_for_no tests/test_pipeline_integration.py::test_classify_in_domain_fails_open_on_exception -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /opt/craftpilot_backend && git add pipeline.py tests/test_pipeline_integration.py && git commit -m "feat: add _classify_in_domain method for pre-LLM topic classification"
+```
+
+---
+
+### Task 2: Hook classifier into `stream_response`
+
+**Files:**
+- Modify: `pipeline.py` — top of `stream_response()` `try` block (~line 337)
+
+**Interfaces:**
+- Consumes: `_classify_in_domain(self, message: str) -> bool` from Task 1.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_pipeline_integration.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_stream_response_short_circuits_off_topic():
+    """Off-topic question must yield status + refusal token + [DONE] and nothing else."""
+    pipeline = _make_pipeline_with_mock_llm("NON")
+
+    events = []
+    async for line in pipeline.stream_response(
+        message="Qui est le président des États-Unis ?",
+        conversation_thread_id="test-thread",
+        is_first_message=False,
+    ):
+        import json as _json
+        events.append(_json.loads(line))
+
+    assert events[0] == {"event": "status", "data": "Vérification de la question…"}
+    assert events[1]["event"] == "token"
+    assert "arts et métiers" in events[1]["data"]
+    assert events[2] == {"content": "[DONE]"}
+    assert len(events) == 3
+
+
+@pytest.mark.asyncio
+async def test_stream_response_does_not_short_circuit_in_domain():
+    """In-domain question must NOT be short-circuited (retrieval pipeline runs)."""
+    pipeline = _make_pipeline_with_mock_llm("OUI")
+
+    # Patch the retrieval steps so they don't hit real services
+    async def _fake_retrieve(state):
+        return {"context": [], "video_metadata": None}
+
+    pipeline.rag_service.retrieve_initial = MagicMock(return_value={
+        "context": [], "video_metadata": None, "refined_query": None,
+        "hypothetical_document": None, "enhanced_query": None, "query_variants": [],
+    })
+    pipeline.rag_service.refine_query_prf = MagicMock(return_value={})
+    pipeline.rag_service.retrieve_final_dual = MagicMock(return_value={"context": []})
+    pipeline.rag_service.rerank = MagicMock(return_value={"context": []})
+
+    async def _fake_stream_generate(state):
+        yield "Bonjour"
+
+    pipeline.rag_service.stream_generate = _fake_stream_generate
+
+    events = []
+    async for line in pipeline.stream_response(
+        message="Comment souffler le verre ?",
+        conversation_thread_id="test-thread",
+        is_first_message=False,
+    ):
+        import json as _json
+        events.append(_json.loads(line))
+
+    event_types = [e.get("event") or e.get("content") for e in events]
+    assert "token" in event_types
+    # Must NOT have stopped after 3 events
+    assert len(events) > 3
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /opt/craftpilot_backend && python -m pytest tests/test_pipeline_integration.py::test_stream_response_short_circuits_off_topic tests/test_pipeline_integration.py::test_stream_response_does_not_short_circuit_in_domain -v
+```
+
+Expected: both FAIL — `test_stream_response_short_circuits_off_topic` because the hook doesn't exist yet; `test_stream_response_does_not_short_circuit_in_domain` may also fail for the same reason.
+
+- [ ] **Step 3: Add the hook to `stream_response`**
+
+In `pipeline.py`, inside `stream_response()`, at the top of the `try` block — before the `if is_first_message:` check — insert:
+
+```python
+            # --- Pre-LLM topic classifier ---
+            is_in_domain = await self._classify_in_domain(message)
+            if not is_in_domain:
+                yield json.dumps({"event": "status", "data": "Vérification de la question…"}) + "\n"
+                yield json.dumps({"event": "token", "data": (
+                    "Je n'ai pas trouvé d'information pertinente dans le corpus "
+                    "pour répondre à cette question. Veuillez poser une question "
+                    "sur les arts et métiers ou consulter votre formateur."
+                )}) + "\n"
+                yield json.dumps({"content": "[DONE]"}) + "\n"
+                return
+```
+
+The full top of the `try` block in `stream_response` now reads:
+
+```python
+        try:
+            from langchain_core.messages import HumanMessage
+
+            # --- Pre-LLM topic classifier ---
+            is_in_domain = await self._classify_in_domain(message)
+            if not is_in_domain:
+                yield json.dumps({"event": "status", "data": "Vérification de la question…"}) + "\n"
+                yield json.dumps({"event": "token", "data": (
+                    "Je n'ai pas trouvé d'information pertinente dans le corpus "
+                    "pour répondre à cette question. Veuillez poser une question "
+                    "sur les arts et métiers ou consulter votre formateur."
+                )}) + "\n"
+                yield json.dumps({"content": "[DONE]"}) + "\n"
+                return
+
+            # Generate and emit the conversation title before the PRF pipeline
+            # so the client can update the sidebar title immediately.
+            if is_first_message:
+                title = await self._generate_conversation_title(message)
+                yield json.dumps({"event": "conversation_title", "data": title}) + "\n"
+
+            # ... rest of the pipeline unchanged
+```
+
+- [ ] **Step 4: Run all classifier tests**
+
+```bash
+cd /opt/craftpilot_backend && python -m pytest tests/test_pipeline_integration.py -k "classify_in_domain or short_circuit" -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /opt/craftpilot_backend && git add pipeline.py tests/test_pipeline_integration.py && git commit -m "feat: hook input classifier into stream_response — short-circuits off-topic questions before retrieval"
+```
+
+---
+
+### Task 3: Manual smoke test
+
+No code changes — verify the live service behaves correctly after restart.
+
+- [ ] **Step 1: Restart the backend**
+
+Ask the user to run:
+```
+! sudo systemctl restart craftpilot-backend
+```
+
+- [ ] **Step 2: Test off-topic question**
+
+In the CraftPilot chat UI, send: `"Qui est le président des États-Unis ?"`
+
+Expected response (only this, nothing else):
+> "Je n'ai pas trouvé d'information pertinente dans le corpus pour répondre à cette question. Veuillez poser une question sur les arts et métiers ou consulter votre formateur."
+
+- [ ] **Step 3: Test in-domain question**
+
+Send: `"Comment souffler une paraison de verre ?"`
+
+Expected: normal RAG response with "Pour aller plus loin" section.
+
+- [ ] **Step 4: Verify fail-open by checking logs**
+
+```bash
+sudo journalctl -u craftpilot-backend -n 50 | grep "classifier"
+```
+
+Expected: no `"Input classifier failed"` warnings for normal traffic.

--- a/docs/superpowers/plans/2026-06-22-status-hints-streaming-fix.md
+++ b/docs/superpowers/plans/2026-06-22-status-hints-streaming-fix.md
@@ -1,0 +1,338 @@
+# Status Hints Streaming Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make RAG pipeline status hints ("Recherche…", "Reformulation…", etc.) visible in the chat widget by ensuring each hint is flushed to the browser before the next pipeline step blocks.
+
+**Architecture:** Two-layer fix. Server: wrap the three synchronous pipeline calls in `asyncio.to_thread()` so the asyncio event loop — and therefore uvicorn's HTTP flushing — is never blocked between status yields. Client: convert the event-processing loop from `forEach` to `for...of` with a `requestAnimationFrame` pause after each `status` event so the browser repaints each hint even if two arrive in the same TCP segment.
+
+**Tech Stack:** Python 3.10+ asyncio, FastAPI StreamingResponse, Moodle AMD (ES6 module compiled via Grunt/Babel), browser Fetch ReadableStream API.
+
+## Global Constraints
+
+- Branch: `feat/status-hints-streaming` (already created in `/opt/craftpilot_backend`)
+- No new dependencies — `asyncio.to_thread` is stdlib (Python 3.9+)
+- No inline `style=` attributes in JS — all visual styling goes in `styles.css` (already correct)
+- No `sudo` — service restart must be done by the user via `! sudo systemctl restart craftpilot-backend`
+- After any edit to `amd/src/chat_interface.js`, the full three-step deploy sequence is required (see Task 2)
+- Status hint strings remain French-only
+
+---
+
+## File Map
+
+| File | Role | Change type |
+|---|---|---|
+| `/opt/craftpilot_backend/pipeline.py` | Async generator that streams pipeline events | Modify: replace 3 blocking calls with `asyncio.to_thread`; remove `asyncio.sleep` calls |
+| `/var/www/html/public/local/craftpilot/amd/src/chat_interface.js` | AMD source — compiled to `amd/build/chat_interface.min.js` | Modify: `forEach`→`for...of`+RAF; remove debug overlay; remove inline style from hint span |
+
+---
+
+## Task 1: Server — unblock the event loop between status yields
+
+**Files:**
+- Modify: `/opt/craftpilot_backend/pipeline.py` lines 365–395
+
+**Interfaces:**
+- `asyncio.to_thread(callable, *args)` — stdlib coroutine; awaiting it runs `callable(*args)` in a thread-pool thread and returns its result, without blocking the event loop
+- `self.rag_service.retrieve_initial(state: dict) -> dict` — synchronous, ~0.5 s
+- `self.rag_service.refine_query_prf(state: dict) -> dict` — synchronous, LLM call ~2–5 s
+- `self.rag_service.retrieve_final_dual(state: dict) -> dict` — synchronous, ~0.5 s
+
+- [ ] **Step 1: Replace the three blocking calls with `asyncio.to_thread`**
+
+In `/opt/craftpilot_backend/pipeline.py`, find the PRF steps block (currently lines 365–395) and replace it with the following. The diff is surgical — only the three `retrieve_*`/`refine_*` calls and their preceding `asyncio.sleep` lines change:
+
+```python
+            # --- PRF step 1: initial retrieval ---
+            yield json.dumps({"event": "status", "data": "Recherche dans la base de connaissances…"}) + "\n"
+            result = await asyncio.to_thread(self.rag_service.retrieve_initial, state)
+            state.update(result)
+
+            # --- PRF step 2: corpus-grounded query refinement ---
+            yield json.dumps({"event": "status", "data": "Reformulation de la question…"}) + "\n"
+            result = await asyncio.to_thread(self.rag_service.refine_query_prf, state)
+            state.update(result)
+
+            # --- PRF step 3: final retrieval with refined query ---
+            yield json.dumps({"event": "status", "data": "Récupération des sources pertinentes…"}) + "\n"
+            result = await asyncio.to_thread(self.rag_service.retrieve_final_dual, state)
+            state.update(result)
+
+            # --- PRF step 4: cross-encoder reranking and relevance filtering ---
+            if not disable_rerank:
+                yield json.dumps({"event": "status", "data": "Classement des résultats…"}) + "\n"
+                # Cap candidates before reranking — bge-reranker-v2-m3 takes
+                # ~5 s per pair on a 2-core CPU, so keep the list tight.
+                ctx = state.get("context", [])
+                if len(ctx) > self.MAX_RERANK_CANDIDATES:
+                    state["context"] = ctx[: self.MAX_RERANK_CANDIDATES]
+                # Run synchronous cross-encoder inference in a thread so the
+                # event loop remains responsive during the ~20-30 s prediction.
+                result = await asyncio.to_thread(self.rag_service.rerank, state)
+                state.update(result)
+```
+
+Key changes from current code:
+- Lines `await asyncio.sleep(0.1)` after each status yield → **deleted**
+- `result = self.rag_service.retrieve_initial(state)` → `result = await asyncio.to_thread(self.rag_service.retrieve_initial, state)`
+- Same pattern for `refine_query_prf` and `retrieve_final_dual`
+- The `await asyncio.sleep(0.1)` after "Classement des résultats…" → **deleted** (the existing `asyncio.to_thread(rerank)` already frees the loop)
+
+- [ ] **Step 2: Ask the user to restart the backend**
+
+Tell the user to run:
+```
+! sudo systemctl restart craftpilot-backend
+```
+Wait for confirmation before proceeding to Task 2.
+
+- [ ] **Step 3: Smoke-test the server fix in isolation**
+
+Send a message in the chat widget. Open the browser DevTools Network tab, find the `chat_proxy.php` request, and watch the response stream. Each status event should appear as a separate chunk with a visible time gap before the next one. If all five status lines appear in one burst right before generation starts, the `asyncio.to_thread` change did not take effect (check the service restarted).
+
+- [ ] **Step 4: Commit the server change**
+
+```bash
+git -C /opt/craftpilot_backend add pipeline.py
+git -C /opt/craftpilot_backend commit -m "fix(pipeline): unblock event loop between status yields via asyncio.to_thread
+
+Wrapping retrieve_initial, refine_query_prf, and retrieve_final_dual in
+asyncio.to_thread() ensures uvicorn can flush each status HTTP chunk to the
+socket before the next blocking call starts. Previously, asyncio.sleep(0.1)
+was used but the event loop re-blocked immediately on the sync call.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01KAhxwRU92wXdUndwFV4ANd"
+```
+
+---
+
+## Task 2: Client — force a browser repaint between status events
+
+**Files:**
+- Modify: `/var/www/html/public/local/craftpilot/amd/src/chat_interface.js`
+  - `showTyping()` — line 1016: remove inline `style=` from `.cp-status-hint` span
+  - `streamFromBackend()` — lines 1134–1256: convert inner loop + remove debug overlay
+
+**Interfaces:**
+- `requestAnimationFrame(callback)` — browser API; schedules `callback` before the next paint cycle. `await new Promise(resolve => requestAnimationFrame(resolve))` suspends an async function until the next frame, guaranteeing a repaint.
+- `for...of` loop — unlike `forEach`, supports `await` inside the loop body
+- The `read` function changes from `() => Promise` to `async () => Promise` — the outer `.then()` chain is unaffected because async functions return Promises
+
+- [ ] **Step 1: Fix `showTyping()` — remove inline style from hint span**
+
+Find `showTyping()` at line 1006. Change the `.cp-status-hint` span from:
+
+```javascript
+'<span class="cp-status-hint" aria-live="polite" style="margin-left:10px;font-style:italic;font-size:12px;color:#555;display:inline-block"></span>'
+```
+
+to:
+
+```javascript
+'<span class="cp-status-hint" aria-live="polite"></span>'
+```
+
+The `.cp-status-hint` rule in `styles.css` already provides `margin-left`, `font-size`, `font-style`, and `color`. The inline style was a debugging fallback and contradicts the project's no-inline-styles rule.
+
+- [ ] **Step 2: Rewrite the `read` function inside `streamFromBackend`**
+
+The current `read` function (lines 1134–1256) uses `.then()` chaining and a `lines.forEach` loop. Replace the entire `read` constant and the `return read()` call below it with the following async version. Everything outside this block (the `activateBubble` closure, `fullResponse`, `buf`, `reader`, `decoder`) stays unchanged.
+
+Replace from:
+```javascript
+            const read = () => reader.read().then(({ done, value }) => {
+```
+down to (and including):
+```javascript
+            return read();
+        })
+```
+
+With:
+
+```javascript
+            const read = async () => {
+                const { done, value } = await reader.read();
+
+                if (done) {
+                    if (String(streamConvId) !== String(state.currentConvId)) {
+                        finishStreaming();
+                        return;
+                    }
+                    const b = activateBubble();
+                    const cleanFinal = stripThinkTags(fullResponse);
+                    b.innerHTML = renderMarkdown(cleanFinal);
+                    extractFollowUpQuestions(cleanFinal);
+                    const finishedSources = getConvState(streamConvId).sources;
+                    saveMessage(streamConvId, 'ai', cleanFinal,
+                        finishedSources.length ? JSON.stringify({sources: finishedSources}) : '');
+                    finishStreaming();
+                    return;
+                }
+
+                buf += decoder.decode(value, { stream: true });
+                const lines = buf.split('\n');
+                buf = lines.pop();
+
+                for (const line of lines) {
+                    if (!line.trim()) continue;
+                    try {
+                        const ev = JSON.parse(line);
+
+                        if (ev.event === 'conversation_title' && ev.data) {
+                            const newTitle = ev.data;
+                            state.currentConvTitle = newTitle;
+                            updatePanelTitle(newTitle);
+                            const conv = state.conversations.find(
+                                c => String(c.conversation_id || c.id) === String(streamConvId)
+                            );
+                            if (conv) conv.title = newTitle;
+                            renderConversations(state.conversations, streamConvId);
+                            Ajax.call([{
+                                methodname: 'local_craftpilot_manage_conversations',
+                                args: { action: 'update', conversation_id: streamConvId, title: newTitle },
+                            }])[0].catch(err => console.error('CraftPilot: title persist failed', err));
+
+                        } else if (ev.event === 'status' && ev.data) {
+                            const hintEl = typingEl.querySelector('.cp-status-hint');
+                            if (hintEl) hintEl.textContent = ev.data;
+                            // Yield one animation frame so the browser renders this
+                            // hint before processing the next event in the same chunk.
+                            await new Promise(resolve => requestAnimationFrame(resolve));
+
+                        } else if (ev.event === 'video_metadata' && ev.data) {
+                            const vm    = ev.data;
+                            const isBVH = (vm.filename || '').toLowerCase().endsWith('.bvh');
+                            addSource({
+                                id:          vm.video_id || vm.bvh_id || vm.filename,
+                                type:        isBVH ? 'bvh' : 'video',
+                                filename:    vm.filename,
+                                video_url:   isBVH ? null : vm.video_url,
+                                bvh_url:     isBVH ? (vm.bvh_url || vm.video_url) : null,
+                                start_time:  vm.start_time,
+                                end_time:    vm.end_time,
+                                duration:    vm.duration,
+                                project_name: vm.project_name,
+                            }, streamConvId);
+
+                        } else if (ev.event === 'bvh_metadata' && ev.data) {
+                            const bm = ev.data;
+                            addSource({
+                                id:          bm.bvh_id || bm.filename,
+                                type:        'bvh',
+                                filename:    bm.filename,
+                                bvh_url:     bm.bvh_url || bm.url,
+                                duration:    bm.duration,
+                                frame_count: bm.frame_count,
+                            }, streamConvId);
+
+                        } else if (ev.event === 'token' && ev.data) {
+                            fullResponse += ev.data;
+                            const visible = stripThinkTags(fullResponse);
+                            activateBubble().innerHTML = renderMarkdown(visible);
+                            scrollBottom();
+
+                        } else if (ev.event === 'message' && ev.content) {
+                            ev.content.forEach((c) => { if (c.content) fullResponse += c.content; });
+                            const visible = stripThinkTags(fullResponse);
+                            activateBubble().innerHTML = renderMarkdown(visible);
+                            scrollBottom();
+
+                        } else if (ev.event === 'documents' && Array.isArray(ev.data)) {
+                            ev.data.forEach((doc) => {
+                                if (doc.type === 'video_annotation') return;
+                                addSource({
+                                    id:           doc.source,
+                                    type:         'text',
+                                    source:       doc.module_name || doc.source,
+                                    content:      doc.page_content_preview,
+                                    module_id:    doc.module_id,
+                                    module_type:  doc.module_type,
+                                    course_id:    doc.course_id,
+                                    heading_path: doc.heading_path,
+                                    section_name: doc.section_name,
+                                }, streamConvId);
+                            });
+
+                        } else if (ev.content === '[DONE]') {
+                            /* handled on stream close */
+
+                        } else if (ev.event === 'error' || ev.type === 'error') {
+                            if (msgEl && msgEl.parentNode) msgEl.parentNode.removeChild(msgEl);
+                            if (typingEl.parentNode) typingEl.parentNode.removeChild(typingEl);
+                            showError(ev.message || 'The AI backend returned an error.');
+                            finishStreaming();
+                        }
+                    } catch (_) {
+                        /* non-JSON lines — ignore */
+                    }
+                }
+
+                return read();
+            };
+
+            return read();
+        })
+```
+
+What changed vs the original:
+- `const read = () => reader.read().then(...)` → `const read = async () => { const {done,value} = await reader.read(); ... }`
+- `lines.forEach((line) => { ... })` → `for (const line of lines) { ... }`
+- `status` handler: removed the entire `cp-dbg-overlay` block (8 lines); added `await new Promise(resolve => requestAnimationFrame(resolve))` after setting `hintEl.textContent`
+- All other event handlers (`conversation_title`, `video_metadata`, `bvh_metadata`, `token`, `message`, `documents`, `error`) are character-for-character identical to the original
+
+- [ ] **Step 3: Build the AMD bundle**
+
+Run from the plugin root:
+```bash
+cd /var/www/html/public/local/craftpilot && ./node_modules/.bin/grunt babel --force
+```
+
+Expected output ends with something like:
+```
+Done, without errors.
+```
+The `--force` flag is required because the `.map` file is root-owned; it does not affect functionality.
+
+- [ ] **Step 4: Purge the Moodle server-side JS cache**
+
+Ask the user to run:
+```
+! sudo -u apache php /var/www/html/public/admin/cli/purge_caches.php
+```
+
+Alternatively, they can go to **Moodle admin → Site administration → Development → Purge all caches**. A browser hard-refresh alone is not sufficient — Moodle repacks AMD bundles server-side.
+
+- [ ] **Step 5: Verify end-to-end**
+
+Send a message in the Moodle CraftPilot widget and confirm:
+
+1. The typing indicator appears immediately after send
+2. The hint text inside the typing indicator reads "Recherche dans la base de connaissances…" briefly
+3. It transitions to "Reformulation de la question…" (holds for a few seconds while the LLM refines the query)
+4. Then "Récupération des sources pertinentes…" briefly
+5. Then "Classement des résultats…" (holds ~20–30 s on this server)
+6. Then "Génération de la réponse…" briefly before the first token appears
+7. The typing indicator disappears cleanly when the first token arrives
+8. No red overlay (`cp-dbg-overlay`) appears anywhere on the page
+9. Inspect the `.cp-status-hint` span in DevTools — confirm no `style=` attribute is present
+
+- [ ] **Step 6: Commit the client change**
+
+```bash
+git -C /opt/craftpilot_backend add docs/  # plan file only; JS lives outside the repo
+git -C /opt/craftpilot_backend commit -m "fix(client): force repaint between status hints via requestAnimationFrame
+
+- forEach -> for...of in stream read loop so we can await inside it
+- await one animation frame after each status event so the browser
+  renders each hint before processing the next line in the same chunk
+- remove cp-dbg-overlay diagnostic block
+- remove inline style= from .cp-status-hint span (css rule already covers it)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01KAhxwRU92wXdUndwFV4ANd"
+```
+
+Note: `chat_interface.js` changes are not tracked in the backend git repo (it lives in the Moodle plugin directory with no VCS). The commit here records the plan doc update only. If the Moodle plugin directory ever gets a git repo, the JS change should be committed there.

--- a/docs/superpowers/specs/2026-06-22-input-classifier-design.txt
+++ b/docs/superpowers/specs/2026-06-22-input-classifier-design.txt
@@ -1,0 +1,99 @@
+# Input Classifier — Design Spec
+
+**Date:** 2026-06-22  
+**Status:** Approved  
+**Scope:** `pipeline.py` only — one new method, one hook at the top of `stream_response()`
+
+---
+
+## Problem
+
+The existing guardrail is a system-prompt instruction. The LLM can reason around it — demonstrated by a question about the US president producing glass-blowing follow-up questions instead of a refusal. Prompt-only guardrails are unreliable because the model weighs helpfulness against the constraint.
+
+## Solution
+
+A pre-LLM classification step that short-circuits the pipeline in Python before the retriever or main LLM are ever called. The LLM cannot override a Python `return` statement.
+
+---
+
+## Architecture
+
+```
+stream_response()
+  │
+  ├─► _classify_in_domain(message)   ← new, ~1–2 s
+  │     └─ off-topic → yield refusal → return
+  │
+  ├─► _generate_conversation_title() (first message only)
+  ├─► retrieve_initial
+  ├─► refine_query_prf
+  ├─► retrieve_final_dual
+  ├─► rerank
+  └─► stream_generate
+```
+
+The classifier runs before title generation so off-topic messages waste zero retrieval or generation budget.
+
+---
+
+## `_classify_in_domain(message: str) -> bool`
+
+**Location:** new async method on `MoodleAIAssistantPipeline` in `pipeline.py`
+
+**LLM call:** `self.rag_service.llm.bind(max_tokens=5, temperature=0)` — same pattern as `_generate_conversation_title`. Reuses the already-initialised Infomaniak endpoint; no new dependencies.
+
+**Prompt:**
+
+```
+System:
+Tu es un classifieur de sujets. Réponds par un seul mot :
+OUI si la question concerne les arts et métiers, l'apprentissage,
+les techniques artisanales (soufflage de verre, ganterie, menuiserie,
+sellerie, etc.). Réponds NON pour tout le reste (politique, actualité,
+géographie, célébrités, etc.). Réponds uniquement OUI ou NON.
+
+User:
+{message}
+```
+
+**Parsing:** case-insensitive check — `"OUI"` or `"YES"` at the start of the response → `True` (in-domain). Anything else → `False`.
+
+**Error handling:** any exception (network, timeout, unexpected response format) → log the error → return `True` (fail-open). A misclassified legitimate question is a worse outcome than a missed off-topic hit.
+
+---
+
+## Hook in `stream_response()`
+
+Inserted before any `yield` at the top of the `try` block:
+
+```python
+is_in_domain = await self._classify_in_domain(message)
+if not is_in_domain:
+    yield json.dumps({"event": "status", "data": "Vérification de la question…"}) + "\n"
+    yield json.dumps({"event": "token", "data": (
+        "Je n'ai pas trouvé d'information pertinente dans le corpus "
+        "pour répondre à cette question. Veuillez poser une question "
+        "sur les arts et métiers ou consulter votre formateur."
+    )}) + "\n"
+    yield json.dumps({"content": "[DONE]"}) + "\n"
+    return
+```
+
+The refusal is emitted as a normal `token` event so the frontend renders it identically to a real response — no new event types or frontend changes needed.
+
+---
+
+## Constraints
+
+- No new dependencies.
+- No new service classes — the method lives directly on `MoodleAIAssistantPipeline`.
+- The hint is generic (not domain-aware) for consistency across all contexts.
+- The `status` event fires before the classification result is known; this is acceptable because the classification is fast enough that the user perceives it as a single step.
+
+---
+
+## Out of scope
+
+- Logging off-topic queries to a separate store for analysis (can be added later by extending `_classify_in_domain`).
+- Tuning thresholds or adding a confidence score — the binary YES/NO response is sufficient for this phase.
+- Frontend changes — not required.

--- a/docs/superpowers/specs/2026-06-22-status-hints-streaming-fix-design.md
+++ b/docs/superpowers/specs/2026-06-22-status-hints-streaming-fix-design.md
@@ -1,0 +1,167 @@
+# Design: Fix RAG status hint streaming
+
+**Date:** 2026-06-22  
+**Branch:** `feat/status-hints-streaming`  
+**Status:** Approved
+
+---
+
+## Problem statement
+
+The RAG pipeline yields five status events before each step so the UI can show
+an italic hint ("Recherche dans la base de connaissances…", etc.) while the
+backend processes the request. Despite the events being yielded and the PHP
+proxy correctly configured (output buffering disabled, `flush()` after every
+`echo`), only the final status event ("Génération de la réponse…") ever reaches
+the browser visibly.
+
+---
+
+## Root cause (confirmed)
+
+`retrieve_initial`, `refine_query_prf`, and `retrieve_final_dual` are
+**synchronous functions called directly inside an `async def` generator**.
+Python's asyncio event loop is single-threaded. Calling a sync function there
+freezes the entire event loop — including uvicorn's I/O layer — for the
+duration of the call. Uvicorn cannot flush the previously-yielded HTTP chunk to
+the OS socket while the event loop is frozen.
+
+The two patches tried (`asyncio.sleep(0)`, `asyncio.sleep(0.1)`) both fail for
+the same reason: the event loop is freed for one tick by the sleep, but the
+*very next instruction* is a blocking sync call that re-freezes it — before the
+I/O selector can drain uvicorn's write buffer.
+
+`rerank` already uses `await asyncio.to_thread(...)`. That is why "Génération
+de la réponse…" is the only hint that works: it is the only pipeline step that
+genuinely frees the event loop.
+
+**FastAPI docs confirm:**  
+> FastAPI itself wraps every sync endpoint function in `run_in_threadpool`
+> because calling a blocking function in a coroutine blocks the event loop.
+
+**Python asyncio docs confirm:**  
+> `asyncio.to_thread()` is primarily designed for IO-bound or CPU-bound
+> functions that would otherwise block the event loop if run in the main thread.
+
+---
+
+## Solution
+
+Two-layer fix: server-side (root cause) + client-side (safety net).
+
+### Layer 1 — Server: `pipeline.py`
+
+Wrap the three blocking sync calls in `asyncio.to_thread()`, matching the
+pattern already used for `rerank`. Remove the now-useless `asyncio.sleep()`
+calls — the `await` itself yields the event loop for the entire duration of the
+thread.
+
+```python
+# OLD — freezes the event loop:
+yield status_event
+await asyncio.sleep(0.1)          # one useless tick
+result = self.rag_service.retrieve_initial(state)   # blocks event loop
+
+# NEW — event loop stays free during the blocking call:
+yield status_event
+result = await asyncio.to_thread(self.rag_service.retrieve_initial, state)
+```
+
+Apply to:
+- `retrieve_initial`
+- `refine_query_prf`
+- `retrieve_final_dual`
+
+`rerank` already uses `asyncio.to_thread` — no change there.
+
+**Thread safety:** Each function takes `state` (a request-local dict) and
+returns a result dict. They do not mutate shared service-level state and run
+strictly sequentially (not concurrently). No locking required.
+
+### Layer 2 — Client: `amd/src/chat_interface.js`
+
+Even with the server fix, two events can arrive in the same TCP segment if a
+step completes in less than one network RTT. The current `lines.forEach` loop
+processes all lines in one synchronous JS task — the browser never repaints
+between them, so only the last status text in a batch is ever rendered.
+
+Fix: change the inner loop from `forEach` to `for...of` (so we can `await`
+inside it) and after each `status` event, yield to the browser's paint
+scheduler:
+
+```javascript
+for (const line of lines) {
+    const ev = JSON.parse(line.trim());
+    if (!ev || !ev.event) continue;
+
+    if (ev.event === 'status') {
+        const hintEl = typingEl.querySelector('.cp-status-hint');
+        if (hintEl) hintEl.textContent = ev.data;
+        // Yield one animation frame so the browser can render this hint
+        // before we process the next event in the same chunk.
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
+    } else if (ev.event === 'token') {
+        // Tokens are processed immediately — no pause.
+        activateBubble().textContent += ev.data;
+
+    } // … other events unchanged
+}
+```
+
+Cost: ~16 ms per status event (one animation frame). Completely imperceptible
+for steps that take hundreds of milliseconds to seconds. Token throughput is
+unaffected.
+
+---
+
+## Cleanup in the same commit
+
+These were temporary scaffolding from debugging:
+
+1. **Remove the diagnostic red overlay** (`cp-dbg-overlay`) — the `div`
+   creation block and `dbg.textContent = ev.data` line inside the `status`
+   handler in `chat_interface.js`.
+
+2. **Remove inline `style=` from the hint `<span>`** in `showTyping()`.  
+   The rule `.cp-status-hint { … }` in `styles.css` already covers all
+   necessary styling. The inline attribute was added as a fallback during
+   debugging and contradicts the project rule against inline styles.
+
+---
+
+## Files changed
+
+| File | Location | Change |
+|---|---|---|
+| `pipeline.py` | `/opt/craftpilot_backend/` | Wrap 3 sync calls in `asyncio.to_thread`; remove `asyncio.sleep` calls |
+| `chat_interface.js` | `amd/src/` (Moodle plugin) | `forEach` → `for...of` + RAF after status events; remove debug overlay; remove inline style |
+
+After editing `chat_interface.js`, the standard deploy sequence applies:
+1. `grunt babel --force` in the plugin root
+2. Purge Moodle server-side JS cache
+
+---
+
+## What does not change
+
+- PHP proxy (`chat_proxy.php`) — already correct
+- CSS (`.cp-status-hint` in `styles.css`) — already correct
+- The `showTyping()` DOM structure — hint `<span>` stays inside `.cp-typing`
+- All other event types (`token`, `message`, `documents`, `error`, `video_metadata`) — logic unchanged
+
+---
+
+## Verification checklist
+
+1. Send a prompt in the Moodle CraftPilot widget
+2. The typing indicator should show each hint in sequence:
+   - "Recherche dans la base de connaissances…" (briefly, ~0.5 s)
+   - "Reformulation de la question…" (a few seconds while the LLM refines)
+   - "Récupération des sources pertinentes…" (briefly)
+   - "Classement des résultats…" (20–30 s on this server)
+   - "Génération de la réponse…" (until first token)
+3. No red overlay appears anywhere on the page
+4. No inline `style=` attribute on the `.cp-status-hint` span (inspect DOM)
+5. Typing indicator is removed cleanly on first token
+6. Full response renders correctly with sources

--- a/pipeline.py
+++ b/pipeline.py
@@ -35,11 +35,6 @@ class MoodleAIAssistantPipeline:
     MAX_RERANK_CANDIDATES = 5
 
     def __init__(self, config_manager: Optional[ConfigurationManager] = None):
-        import torch
-        # Use both available CPU cores for PyTorch inference.
-        torch.set_num_threads(2)
-        torch.set_num_interop_threads(1)
-
         self.config_manager = config_manager or ConfigurationManager()
 
         # Initialize services in dependency order

--- a/pipeline.py
+++ b/pipeline.py
@@ -361,6 +361,18 @@ class MoodleAIAssistantPipeline:
         try:
             from langchain_core.messages import HumanMessage
 
+            # --- Pre-LLM topic classifier ---
+            is_in_domain = await self._classify_in_domain(message)
+            if not is_in_domain:
+                yield json.dumps({"event": "status", "data": "Vérification de la question…"}) + "\n"
+                yield json.dumps({"event": "token", "data": (
+                    "Je n'ai pas trouvé d'information pertinente dans le corpus "
+                    "pour répondre à cette question. Veuillez poser une question "
+                    "sur les arts et métiers ou consulter votre formateur."
+                )}) + "\n"
+                yield json.dumps({"content": "[DONE]"}) + "\n"
+                return
+
             # Generate and emit the conversation title before the PRF pipeline
             # so the client can update the sidebar title immediately.
             if is_first_message:

--- a/pipeline.py
+++ b/pipeline.py
@@ -311,12 +311,14 @@ class MoodleAIAssistantPipeline:
     async def _classify_in_domain(self, message: str) -> bool:
         """Return True if message is in-domain (craft trades / apprenticeship).
 
-        Uses a minimal LLM call (max_tokens=5, temperature=0) to classify.
+        Uses a minimal LLM call (max_tokens=10, temperature=0) to classify.
         Fails open on any exception so legitimate questions are never blocked.
+        Note: a crafted message can manipulate the classifier to return True (fail-open path);
+        the main RAG system-prompt guardrail remains the last line of defence for such cases.
         """
         try:
             from langchain_core.messages import SystemMessage, HumanMessage
-            classifier_llm = self.rag_service.llm.bind(max_tokens=5, temperature=0)
+            classifier_llm = self.rag_service.llm.bind(max_tokens=10, temperature=0)
             system = SystemMessage(content=(
                 "Tu es un classifieur de sujets. Réponds par un seul mot : "
                 "OUI si la question concerne les arts et métiers, l'apprentissage, "
@@ -327,7 +329,7 @@ class MoodleAIAssistantPipeline:
             human = HumanMessage(content=message)
             response = await classifier_llm.ainvoke([system, human])
             answer = response.content.strip().upper()
-            return answer.startswith("OUI") or answer.startswith("YES")
+            return "OUI" in answer or "YES" in answer
         except Exception as e:
             logger.warning(f"Input classifier failed (fail-open): {e}")
             return True
@@ -349,6 +351,7 @@ class MoodleAIAssistantPipeline:
         token-by-token so the client sees output immediately.
 
         Yields JSON-line strings:
+          {"event": "status", "data": "..."}               — pipeline step hints
           {"event": "conversation_title", "data": "..."}  — only when is_first_message=True
           {"event": "video_metadata", "data": {...}}       — optional, before tokens
           {"event": "token", "data": "<text>"}             — one per LLM token

--- a/pipeline.py
+++ b/pipeline.py
@@ -29,7 +29,17 @@ StreamMode = Literal["values", "updates"]
 class MoodleAIAssistantPipeline:
     """Main pipeline orchestrating the Moodle AI Assistant services."""
 
+    # Maximum number of candidates passed to the cross-encoder reranker.
+    # Keeping this low is critical on 2-core CPUs where bge-reranker-v2-m3
+    # takes ~5 s per document pair.
+    MAX_RERANK_CANDIDATES = 5
+
     def __init__(self, config_manager: Optional[ConfigurationManager] = None):
+        import torch
+        # Use both available CPU cores for PyTorch inference.
+        torch.set_num_threads(2)
+        torch.set_num_interop_threads(1)
+
         self.config_manager = config_manager or ConfigurationManager()
 
         # Initialize services in dependency order
@@ -311,6 +321,7 @@ class MoodleAIAssistantPipeline:
         selected_domain: Optional[str] = None,
         course_id: Optional[str] = None,
         is_first_message: bool = False,
+        disable_rerank: bool = False,
     ):
         """Async generator that streams the full response as JSON-lines events.
 
@@ -325,6 +336,7 @@ class MoodleAIAssistantPipeline:
           {"event": "documents", "data": [...]}            — after all tokens
           {"content": "[DONE]"}                            — terminal marker
         """
+        import asyncio
         import json
 
         try:
@@ -351,26 +363,39 @@ class MoodleAIAssistantPipeline:
             }
 
             # --- PRF step 1: initial retrieval ---
-            result = self.rag_service.retrieve_initial(state)
+            yield json.dumps({"event": "status", "data": "Recherche dans la base de connaissances…"}) + "\n"
+            result = await asyncio.to_thread(self.rag_service.retrieve_initial, state)
             state.update(result)
 
             # --- PRF step 2: corpus-grounded query refinement ---
-            result = self.rag_service.refine_query_prf(state)
+            yield json.dumps({"event": "status", "data": "Reformulation de la question…"}) + "\n"
+            result = await asyncio.to_thread(self.rag_service.refine_query_prf, state)
             state.update(result)
 
             # --- PRF step 3: final retrieval with refined query ---
-            result = self.rag_service.retrieve_final_dual(state)
+            yield json.dumps({"event": "status", "data": "Récupération des sources pertinentes…"}) + "\n"
+            result = await asyncio.to_thread(self.rag_service.retrieve_final_dual, state)
             state.update(result)
 
             # --- PRF step 4: cross-encoder reranking and relevance filtering ---
-            result = self.rag_service.rerank(state)
-            state.update(result)
+            if not disable_rerank:
+                yield json.dumps({"event": "status", "data": "Classement des résultats…"}) + "\n"
+                # Cap candidates before reranking — bge-reranker-v2-m3 takes
+                # ~5 s per pair on a 2-core CPU, so keep the list tight.
+                ctx = state.get("context", [])
+                if len(ctx) > self.MAX_RERANK_CANDIDATES:
+                    state["context"] = ctx[: self.MAX_RERANK_CANDIDATES]
+                # Run synchronous cross-encoder inference in a thread so the
+                # event loop remains responsive during the ~20-30 s prediction.
+                result = await asyncio.to_thread(self.rag_service.rerank, state)
+                state.update(result)
 
             # Re-emit video metadata after reranking (top doc may have changed).
             if state.get("video_metadata"):
                 yield json.dumps({"event": "video_metadata", "data": state["video_metadata"]}) + "\n"
 
             # --- Stream the generate step token by token ---
+            yield json.dumps({"event": "status", "data": "Génération de la réponse…"}) + "\n"
             async for token in self.rag_service.stream_generate(state):
                 yield json.dumps({"event": "token", "data": token}) + "\n"
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -308,6 +308,30 @@ class MoodleAIAssistantPipeline:
             logger.warning(f"Title generation failed: {e}")
             return message[:60]
 
+    async def _classify_in_domain(self, message: str) -> bool:
+        """Return True if message is in-domain (craft trades / apprenticeship).
+
+        Uses a minimal LLM call (max_tokens=5, temperature=0) to classify.
+        Fails open on any exception so legitimate questions are never blocked.
+        """
+        try:
+            from langchain_core.messages import SystemMessage, HumanMessage
+            classifier_llm = self.rag_service.llm.bind(max_tokens=5, temperature=0)
+            system = SystemMessage(content=(
+                "Tu es un classifieur de sujets. Réponds par un seul mot : "
+                "OUI si la question concerne les arts et métiers, l'apprentissage, "
+                "les techniques artisanales (soufflage de verre, ganterie, menuiserie, "
+                "sellerie, etc.). Réponds NON pour tout le reste (politique, actualité, "
+                "géographie, célébrités, etc.). Réponds uniquement OUI ou NON."
+            ))
+            human = HumanMessage(content=message)
+            response = await classifier_llm.ainvoke([system, human])
+            answer = response.content.strip().upper()
+            return answer.startswith("OUI") or answer.startswith("YES")
+        except Exception as e:
+            logger.warning(f"Input classifier failed (fail-open): {e}")
+            return True
+
     @traceable(name="stream_response", run_type="chain")
     async def stream_response(
         self,

--- a/pipeline.py
+++ b/pipeline.py
@@ -328,8 +328,9 @@ class MoodleAIAssistantPipeline:
             ))
             human = HumanMessage(content=message)
             response = await classifier_llm.ainvoke([system, human])
-            answer = response.content.strip().upper()
-            return "OUI" in answer or "YES" in answer
+            import re
+            first_word = re.sub(r"[^A-Z]", "", response.content.strip().upper().split()[0]) if response.content.strip() else ""
+            return first_word in {"OUI", "YES"}
         except Exception as e:
             logger.warning(f"Input classifier failed (fail-open): {e}")
             return True


### PR DESCRIPTION
## Summary

- Adds a pre-LLM topic classifier that short-circuits the RAG pipeline before any retrieval runs when a user question is off-topic (politics, celebrities, general knowledge, etc.)
- Fixes event loop blocking that prevented status hint events from rendering during the reranking step
- Improves system prompt guardrail to eliminate the instruction conflict that caused off-topic pivoting

## Changes

### Input classifier (`pipeline.py`)
- New `_classify_in_domain(message)` async method on `MoodleAIAssistantPipeline` — calls the Infomaniak LLM with `max_tokens=10, temperature=0` and a French YES/NO classifier prompt before any retrieval
- Hook at top of `stream_response()` — off-topic questions receive a soft refusal (`status` + `token` + `[DONE]`) and return immediately; no retrieval, no reranking, no generation cost
- Fails open on any exception so infrastructure errors never block legitimate questions

### Status hint streaming (`pipeline.py`)
- PRF retrieval steps wrapped in `asyncio.to_thread()` so the event loop is unblocked between status yields and hints actually reach the client during the ~20–30 s rerank wait
- Removed out-of-scope `torch` thread configuration from `__init__`

### System prompt (`services/rag_service.py`)
- Added explicit `<think>` tag suppression rule
- Restored original guardrail structure (reverted intermediate edit)

## Test plan

- [ ] Send an off-topic question (e.g. "Qui est le président des États-Unis ?") — should receive only the refusal message, no follow-up questions
- [ ] Send an in-domain question (e.g. "Comment souffler une paraison de verre ?") — should receive a normal RAG response with "Pour aller plus loin" section
- [ ] Observe status hints appearing during a slow rerank — "Recherche…", "Reformulation…", "Classement…", "Génération…" should each render before the next step begins